### PR TITLE
add ISO compliance gate

### DIFF
--- a/.github/workflows/pr-iso-compliance.yml
+++ b/.github/workflows/pr-iso-compliance.yml
@@ -1,0 +1,32 @@
+name: PR ISO Compliance
+
+# ISO 27001 / SOC 2 control: enforce automated unit-test gate on every PR.
+# The job name `iso-compliance` is the status-check context required by the
+# org-level branch ruleset.
+
+on:
+  pull_request:
+
+permissions:
+  contents: read
+
+jobs:
+  iso-compliance:
+    name: iso-compliance
+    runs-on: ubuntu-22.04
+    timeout-minutes: 15
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@v4
+
+      - name: Setup Node.js 20
+        uses: actions/setup-node@v4
+        with:
+          node-version: '20'
+          cache: 'npm'
+
+      - name: Install dependencies
+        run: npm ci || npm install
+
+      - name: Run unit tests
+        run: npm test

--- a/package.json
+++ b/package.json
@@ -47,7 +47,7 @@
   },
   "husky": {
     "hooks": {
-      "pre-commit": "lint-staged && npm run test"
+      "pre-commit": "lint-staged"
     }
   },
   "lint-staged": {


### PR DESCRIPTION
Adds iso-compliance check that runs on every PR (ISO 27001/SOC 2 control). Also disables jest from the husky pre-commit hook — lint-staged still runs.