### PR TITLE
configure dependabot

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,0 +1,18 @@
+# Dependabot configuration.
+# `open-pull-requests-limit` is set high so security-update PRs aren't
+# capped at the default of 5 — Dependabot opens one PR per vulnerable
+# package and the ISO-compliance ruleset gates each on the iso-compliance
+# status check before merge.
+version: 2
+updates:
+  - package-ecosystem: "npm"
+    directory: "/"
+    schedule:
+      interval: "weekly"
+    open-pull-requests-limit: 50
+
+  - package-ecosystem: "github-actions"
+    directory: "/"
+    schedule:
+      interval: "weekly"
+    open-pull-requests-limit: 20


### PR DESCRIPTION
Adds .github/dependabot.yml so Dependabot creates PRs for every flagged dependency without being capped at the 5-PR default limit. Each spawned PR will be gated by the iso-compliance check before merge.